### PR TITLE
make getindex shorter and faster

### DIFF
--- a/src/Cuba.jl
+++ b/src/Cuba.jl
@@ -120,7 +120,7 @@ immutable Integral
     nregions::Int32
 end
 
-Base.getindex(x::Integral, n::Integer) = getfield(x, fieldname(Integral, n))
+Base.getindex(x::Integral, n::Integer) = getfield(x, n)
 Base.start(x::Integral)   = 1
 Base.next(x::Integral, i) = (x[i], i + 1)
 Base.done(x::Integral, i) = (i > 6)


### PR DESCRIPTION
`getfield(x, n)` has the same effect as `getfield(x, fieldname(Integral, n))`, but is faster:
```julia
julia> using BenchmarkTools                                                                                                                                                                         
                                                                                                                                                                                                    
julia> immutable Foo                                                                                                                                                                                
         x::Int64                                                                                                                                                                                   
         y::Float64                                                                                                                                                                                 
       end                                                                                                                                                                                          
                                                                                                                                                                                                    
julia> foo=Foo(2,3)                                                                                                                                                                                 
Foo(2,3.0)                                                                                                                                                                                          
                                                                                                                                                                                                    
julia> @benchmark getfield(foo, 1)                                                                                                                                                                  
BenchmarkTools.Trial:                                                                                                                                                                               
  memory estimate:  0 bytes                                                                                                                                                                         
  allocs estimate:  0                                                                                                                                                                               
  --------------                                                                                                                                                                                    
  minimum time:     16.891 ns (0.00% GC)                                                                                                                                                            
  median time:      16.904 ns (0.00% GC)                                                                                                                                                            
  mean time:        17.243 ns (0.00% GC)                                                                                                                                                            
  maximum time:     43.376 ns (0.00% GC)                                                                                                                                                            
  --------------                                                                                                                                                                                    
  samples:          10000                                                                                                                                                                           
  evals/sample:     998                                                                                                                                                                             
                                                                                                                                                                                                    
julia> @benchmark getfield(foo, fieldname(Foo, 1))                                                                                                                                                  
BenchmarkTools.Trial:                                                                                                                                                                               
  memory estimate:  0 bytes                                                                                                                                                                         
  allocs estimate:  0                                                                                                                                                                               
  --------------                                                                                                                                                                                    
  minimum time:     23.665 ns (0.00% GC)                                                                                                                                                            
  median time:      23.709 ns (0.00% GC)                                                                                                                                                            
  mean time:        24.441 ns (0.00% GC)                                                                                                                                                            
  maximum time:     128.074 ns (0.00% GC)                                                                                                                                                           
  --------------                                                                                                                                                                                    
  samples:          10000                                                                                                                                                                           
  evals/sample:     996                                                                                                                                                                             
                                                                                                                                                                                                    
```