### PR TITLE
Throw an error when `maxevals > typemax(Int64)÷2` in `suave`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -167,6 +167,12 @@ julia> typemax(Int64)
 9223372036854775807
 ```
 
+!!! warning "`maxevals` in Suave"
+
+    Due to an [upstream bug](https://github.com/giordano/Cuba.jl/issues/27),
+	the `suave` routine cannot handle `maxevals` larger than 4611686018427387903
+	(== `typemax(Int) ÷ 2`).
+
 There is no way to overcome this limit. See the following sections for
 the meaning of each argument.
 

--- a/src/suave.jl
+++ b/src/suave.jl
@@ -86,6 +86,9 @@ function suave(integrand::T, ndim::Integer=1, ncomp::Integer=1;
                statefile::AbstractString=STATEFILE, spin::Ptr{Cvoid}=SPIN,
                reltol=missing, abstol=missing, userdata=missing) where {T}
     atol_,rtol_ = tols(atol,rtol,abstol,reltol)
+    # See <https://github.com/giordano/Cuba.jl/issues/27>.
+    max_maxevals = typemax(Int64) ÷ 2
+    maxevals > max_maxevals && throw(ArgumentError("`maxevals` can't be larger than $(max_maxevals) in `suave`, found $(maxevals)"))
     return dointegrate(Suave(integrand, userdata, ndim, ncomp, Int64(nvec), Cdouble(rtol_),
                              Cdouble(atol_), flags, seed, trunc(Int64, minevals),
                              trunc(Int64, maxevals), Int64(nnew), Int64(nmin),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,10 @@ end
             Cuba.KEY, Cuba.STATEFILE, Cuba.SPIN))))
 end
 
+@testset "Misc" begin
+    # https://github.com/giordano/Cuba.jl/issues/27
+    @test_throws ArgumentError suave((x,f) -> f[1] = 1; maxevals=typemax(Int64)÷2 + 1)
+end
 
 # Make sure these functions don't crash.
 Cuba.init(C_NULL, C_NULL)


### PR DESCRIPTION
Fix #27.